### PR TITLE
add blog to header and footer lists

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -30,6 +30,9 @@
             <li class="menu__item">
               <a href="https://www.meetup.com/codepod/" target="_blank" rel="noopener noreferrer">Meetups</a>
             </li>
+            <li class="menu__item blog">
+              <a href="https://codepoduk.github.io/blog/">blog</a>
+            </li>
             <li class="menu__item message-us button">
               <a href="#message-us">Message Us</a>
             </li>
@@ -118,6 +121,9 @@
             </li>
             <li class="menu__item">
               <a href="https://www.meetup.com/codepod/" target="_blank" rel="noopener noreferrer">Meetups</a>
+            </li>
+            <li class="menu__item blog">
+              <a href="https://codepoduk.github.io/blog/">Blog</a>
             </li>
             <li class="menu__item message-us">
               <a href="#message-us">Message Us</a>


### PR DESCRIPTION
Link to code pod blog added to header and footers. 

Seems pretty straightforward. As far as I'm aware there is nothing else needed, though it's possible I've overlooked some interaction?

Will add a link back to the website from the blog.